### PR TITLE
lint 추가해서 경고들 무시

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="UnusedResources" severity="ignore" />
+    <issue id="HardcodedText" severity="ignore" />
+    <issue id="ClickableViewAccessibility" severity="ignore" />
+    <issue id="ContentDescription" severity="ignore" />
+    <issue id="IconXmlAndPng" severity="ignore" />
+</lint>


### PR DESCRIPTION
`lint.xml` 을 `app` 폴더에 추가하고 무시하고 싶은 경고들을 적어두면 

하드코딩 텍스트 같은 경고들을 에디터에서 안뜨게 할 수 있습니다

[공식문서](https://developer.android.com/studio/write/lint#pref)