### PR TITLE
생성: SPUtil, UniqueIdentifier for 고유한 유저 아이디

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
+
+    implementation 'androidx.security:security-crypto:1.1.0-alpha03'
 }
 
 dependencies {

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -8,4 +8,5 @@
     <issue id="SetTextI18n" severity="ignore" />
     <issue id="RtlHardcoded" severity="ignore" />
     <issue id="SpUsage" severity="ignore" />
+    <issue id="ApplySharedPref" severity="ignore" />
 </lint>

--- a/app/src/main/java/team/weathy/MainApplication.kt
+++ b/app/src/main/java/team/weathy/MainApplication.kt
@@ -4,20 +4,27 @@ import android.app.Application
 import androidx.lifecycle.ProcessLifecycleOwner
 import team.weathy.util.FlipperUtil
 import team.weathy.util.PixelRatio
+import team.weathy.util.SPUtil
+import team.weathy.util.UniqueIdentifier
 import team.weathy.util.location.LocationUtil
 
 
 class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        initSingletons()
+        initializeSingletons()
         configureFlipper()
     }
 
-    private fun initSingletons() {
+    /**
+     * Simple and easy dependency injection :)
+     */
+    private fun initializeSingletons() {
         pixelRatio = PixelRatio(this)
         locationUtil = LocationUtil(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(locationUtil)
+        spUtil = SPUtil(this)
+        uniqueId = UniqueIdentifier(spUtil)
     }
 
     private fun configureFlipper() {
@@ -27,5 +34,7 @@ class MainApplication : Application() {
     companion object {
         lateinit var pixelRatio: PixelRatio
         lateinit var locationUtil: LocationUtil
+        lateinit var spUtil: SPUtil
+        lateinit var uniqueId: UniqueIdentifier
     }
 }

--- a/app/src/main/java/team/weathy/util/SPUtil.kt
+++ b/app/src/main/java/team/weathy/util/SPUtil.kt
@@ -1,0 +1,18 @@
+package team.weathy.util
+
+import android.app.Application
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV
+import androidx.security.crypto.EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+import androidx.security.crypto.MasterKey
+
+class SPUtil(context: Application) {
+    private val masterKey = MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
+    val sharedPreferences = EncryptedSharedPreferences.create(
+        context, SP_NAME, masterKey, AES256_SIV, AES256_GCM
+    )
+
+    companion object {
+        private const val SP_NAME = "DO_NOT_CHANGE_THIS"
+    }
+}

--- a/app/src/main/java/team/weathy/util/UniqueIdentifier.kt
+++ b/app/src/main/java/team/weathy/util/UniqueIdentifier.kt
@@ -11,7 +11,7 @@ class UniqueIdentifier(private val spUtil: SPUtil) {
             }
         }
 
-    val isUniqueIdExist
+    val exist
         get() = spUtil.sharedPreferences.contains(KEY)
 
     private fun generate() = UUID.randomUUID()

--- a/app/src/main/java/team/weathy/util/UniqueIdentifier.kt
+++ b/app/src/main/java/team/weathy/util/UniqueIdentifier.kt
@@ -1,0 +1,22 @@
+package team.weathy.util
+
+import java.util.*
+
+class UniqueIdentifier(private val spUtil: SPUtil) {
+    val id
+        get() = spUtil.sharedPreferences.getString(KEY, null).let { savedId ->
+            debugE(savedId)
+            savedId ?: generate().toString().also { id ->
+                spUtil.sharedPreferences.edit().putString(KEY, id).commit()
+            }
+        }
+
+    val isUniqueIdExist
+        get() = spUtil.sharedPreferences.contains(KEY)
+
+    private fun generate() = UUID.randomUUID()
+
+    companion object {
+        private const val KEY = "UNIQUE_ID"
+    }
+}


### PR DESCRIPTION
### SPUtil

`SharedPreferences`를 가져올 수 있는 유틸리티입니다
`spUtil.sharedPrerences.XXX` 로 함수 사용

### UniqueIdentifier

유저의 고유한 아이디값을 가져오고 저장하기 위한 유틸리티입니다
`uniqueId.id`: 유니크 아이디 가져옴. 없으면 생성
`uniqueId.exist`: 유니크 아이디가 현재 생성이 된 상태인지 

----

둘다 `MainApplication` 에서 싱글톤으로 만듭니다